### PR TITLE
Don't use 'localhost' in messages

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -54,7 +54,6 @@ func compileRegexList(stringList *[]string) ([]*regexp.Regexp, error) {
 }
 
 func (m *Messenger) GenerateMessage(target *ResolvedBackupTarget, subjectTemplateString string, templateString string, errorString string) (string, string, error) {
-	//these must be in the same order as DatabseSubstitutionTags above!
 	hostname := target.Database.Host
 	if hostname == "localhost" { //not very useful for an email message!
 		h, getErr := os.Hostname()
@@ -65,7 +64,8 @@ func (m *Messenger) GenerateMessage(target *ResolvedBackupTarget, subjectTemplat
 		}
 	}
 
-	databaseSubValues := []string{target.Database.Name, target.Database.Host, string(target.Database.Port), target.Database.DBName}
+	//these must be in the same order as DatabseSubstitutionTags above!
+	databaseSubValues := []string{target.Database.Name, hostname, string(target.Database.Port), target.Database.DBName}
 	if len(databaseSubValues) < len(m.CompiledDatabaseSubstitutions) {
 		log.Printf("ERROR: Not enough substitution values. This probably indicates a code bug.")
 		return "", "", errors.New("not enough substitution values")

--- a/messenger.go
+++ b/messenger.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"log"
+	"os"
 	"regexp"
 	"time"
 )
@@ -54,6 +55,16 @@ func compileRegexList(stringList *[]string) ([]*regexp.Regexp, error) {
 
 func (m *Messenger) GenerateMessage(target *ResolvedBackupTarget, subjectTemplateString string, templateString string, errorString string) (string, string, error) {
 	//these must be in the same order as DatabseSubstitutionTags above!
+	hostname := target.Database.Host
+	if hostname == "localhost" { //not very useful for an email message!
+		h, getErr := os.Hostname()
+		if getErr != nil {
+			log.Printf("Could not determine hostname: %s. Sticking with localhost", getErr)
+		} else {
+			hostname = h
+		}
+	}
+
 	databaseSubValues := []string{target.Database.Name, target.Database.Host, string(target.Database.Port), target.Database.DBName}
 	if len(databaseSubValues) < len(m.CompiledDatabaseSubstitutions) {
 		log.Printf("ERROR: Not enough substitution values. This probably indicates a code bug.")

--- a/netapp/deletesnapshot.go
+++ b/netapp/deletesnapshot.go
@@ -1,0 +1,38 @@
+package netapp
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	url2 "net/url"
+)
+
+func DeleteSnapshot(config *NetappConfig, volume *NetappEntity, snapshotId string) error {
+	httpClient := &http.Client{}
+
+	log.Printf("INFO Deleting snapshot %s from volume %s", snapshotId, volume.Name)
+
+	url := url2.URL{
+		Scheme: "https",
+		Host:   config.Host,
+		Path:   fmt.Sprintf("/api/storage/volumes/%s/snapshots/%s", volume.UUID, snapshotId),
+	}
+
+	req, _ := http.NewRequest("DELETE", url.String(), nil)
+	req.SetBasicAuth(config.User, config.Passwd)
+
+	response, httpErr := httpClient.Do(req)
+
+	if httpErr != nil {
+		log.Printf("Could not make HTTP request: %s", httpErr)
+		return httpErr
+	}
+
+	defer response.Body.Close()
+	if response.StatusCode != 202 {
+		log.Printf("ERROR Could not delete snapshot, server returned %d", response.StatusCode)
+		return errors.New("could not delete snapshot")
+	}
+	return nil
+}

--- a/netapp/listsnapshot.go
+++ b/netapp/listsnapshot.go
@@ -1,0 +1,63 @@
+package netapp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	url2 "net/url"
+)
+
+func ListSnapshots(config *NetappConfig, volume *NetappEntity) (*ListSnapshotsResponse, error) {
+	httpClient := &http.Client{}
+
+	log.Printf("INFO Listing snapshots from %s", volume.Name)
+
+	url := url2.URL{
+		Scheme:   "https",
+		Host:     config.Host,
+		Path:     fmt.Sprintf("/api/storage/volumes/%s/snapshots", volume.UUID),
+		RawQuery: fmt.Sprintf("volume.uuid=%s", url2.QueryEscape(volume.UUID)),
+	}
+
+	log.Printf("DEBUG URL is %s", url.String())
+
+	req, _ := http.NewRequest("GET", url.String(), nil)
+	req.SetBasicAuth(config.User, config.Passwd)
+
+	response, httpErr := httpClient.Do(req)
+
+	if httpErr != nil {
+		log.Printf("ERROR Could not make HTTP request: %s", httpErr)
+		return nil, httpErr
+	}
+
+	bodyContent, readErr := ioutil.ReadAll(response.Body)
+	if readErr != nil {
+		log.Print("ERROR Could not read in response from server: ", readErr)
+		return nil, readErr
+	}
+
+	if response.StatusCode == 200 {
+		var response ListSnapshotsResponse
+		marshalErr := json.Unmarshal(bodyContent, &response)
+		if marshalErr != nil {
+			log.Printf("ERROR Offending content was '%s'", string(bodyContent))
+			log.Print("ERROR Could not parse response from server: ", marshalErr)
+			return nil, marshalErr
+		}
+		return &response, nil
+	} else {
+		var response ErrorResponse
+		marshalErr := json.Unmarshal(bodyContent, &response)
+		if marshalErr != nil {
+			log.Printf("ERROR Offending content was '%s'", string(bodyContent))
+			log.Print("ERROR Could not parse response from server: ", marshalErr)
+			return nil, marshalErr
+		}
+		log.Print("ERROR Could not list snapshots: ", response.Error.Message)
+		return nil, errors.New(response.Error.Message)
+	}
+}

--- a/netapp/listsnapshot_test.go
+++ b/netapp/listsnapshot_test.go
@@ -1,0 +1,103 @@
+package netapp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+/**
+ListsnapshotResponse should parse out of the example JSON provided
+*/
+func TestListSnapshotResponse_Parse(t *testing.T) {
+	exampleRawJson := `{
+  "records": [
+    {
+      "volume": {
+        "_links": {
+          "self": {
+            "href": "/api/resourcelink"
+          }
+        },
+        "name": "volume1",
+        "uuid": "028baa66-41bd-11e9-81d5-00a0986138f7"
+      },
+      "_links": {
+        "self": {
+          "href": "/api/resourcelink"
+        }
+      },
+      "name": "this_snapshot",
+      "create_time": "2019-02-04T19:00:00Z",
+      "uuid": "1cd8a442-86d1-11e0-ae1c-123478563412",
+      "expiry_time": "2019-02-04T19:00:00Z",
+      "state": "valid",
+      "snaplock_expiry_time": "2019-02-04T19:00:00Z",
+      "comment": "string",
+      "svm": {
+        "_links": {
+          "self": {
+            "href": "/api/resourcelink"
+          }
+        },
+        "name": "svm1",
+        "uuid": "02c9e252-41be-11e9-81d5-00a0986138f7"
+      }
+    }
+  ],
+  "_links": {
+    "next": {
+      "href": "/api/resourcelink"
+    },
+    "self": {
+      "href": "/api/resourcelink"
+    }
+  },
+  "num_records": 1
+}`
+
+	var resp ListSnapshotsResponse
+
+	err := json.Unmarshal([]byte(exampleRawJson), &resp)
+	if err != nil {
+		t.Errorf("unmarshal returned unexpected error: %s", err)
+		t.FailNow()
+	}
+
+	if resp.RecordsCount != 1 {
+		t.Errorf("got invalid records count, expected 1 got %d", resp.RecordsCount)
+	}
+
+	if len(resp.Records) != 1 {
+		t.Errorf("expected 1 record got %d", len(resp.Records))
+		if len(resp.Records) < 1 {
+			t.FailNow()
+		}
+	}
+
+	rec := resp.Records[0]
+
+	if rec.Name != "this_snapshot" {
+		t.Error("got incorrect snapshot name")
+	}
+	expectedCreateTime, _ := time.Parse(time.RFC3339, "2019-02-04T19:00:00Z")
+	if rec.CreateTime != expectedCreateTime {
+		t.Error("got incorrect create time")
+	}
+	if rec.SnapshotId != "1cd8a442-86d1-11e0-ae1c-123478563412" {
+		t.Error("got incorrect snapshot ID")
+	}
+	expectedExpiryTime, _ := time.Parse(time.RFC3339, "2019-02-04T19:00:00Z")
+	if rec.ExpiryTime != expectedExpiryTime {
+		t.Error("got incorrect expiry time")
+	}
+	if rec.State != "valid" {
+		t.Error("got incorrect state")
+	}
+	if rec.SnaplockExpiryTime != expectedExpiryTime {
+		t.Error("got incorrect snaplock expiry time")
+	}
+	if rec.Comment != "string" {
+		t.Error("got incorrect comment")
+	}
+}

--- a/netapp/models.go
+++ b/netapp/models.go
@@ -1,5 +1,7 @@
 package netapp
 
+import "time"
+
 type NetappConfig struct {
 	Host   string `yaml:"host"`
 	User   string `yaml:"user"`
@@ -28,6 +30,25 @@ type JobResponse struct {
 
 type CreateSnapshotResponse struct {
 	Job JobResponse `json:"job"`
+}
+
+type DeleteSnapshotResponse struct {
+	Job JobResponse `json:"job"`
+}
+
+type SnapshotEntry struct {
+	Name               string    `json:"name"`
+	CreateTime         time.Time `json:"create_time"`
+	SnapshotId         string    `json:"uuid"`
+	ExpiryTime         time.Time `json:"expiry_time"`
+	State              string    `json:"state"`
+	SnaplockExpiryTime time.Time `json:"snaplock_expiry_time"`
+	Comment            string    `json:"comment"`
+}
+
+type ListSnapshotsResponse struct {
+	Records      []SnapshotEntry `json:"records"`
+	RecordsCount int32           `json:"num_records"`
 }
 
 type ErrorArguments struct {


### PR DESCRIPTION
If the target hostname is 'localhost', then substitute the result of os.Hostname() instead to get the actual hostname as determine from the OS